### PR TITLE
Bugfix for set(Left|Right)Ledge:

### DIFF
--- a/ViewDeck/IIViewDeckController.m
+++ b/ViewDeck/IIViewDeckController.m
@@ -259,6 +259,8 @@
 #pragma mark - ledges
 
 - (void)setLeftLedge:(CGFloat)leftLedge {
+    // Compute the final ledge in two steps. This prevents a strange bug where
+    // nesting MAX(X, MIN(Y, Z)) with miniscule referenceBounds returns a bogus near-zero value.
     CGFloat minLedge = MIN(self.referenceBounds.size.width, leftLedge);
     leftLedge = MAX(leftLedge, minLedge);
     if (_viewAppeared && II_FLOAT_EQUAL(self.slidingControllerView.frame.origin.x, self.referenceBounds.size.width - _leftLedge)) {
@@ -277,6 +279,8 @@
 }
 
 - (void)setRightLedge:(CGFloat)rightLedge {
+    // Compute the final ledge in two steps. This prevents a strange bug where
+    // nesting MAX(X, MIN(Y, Z)) with miniscule referenceBounds returns a bogus near-zero value.
     CGFloat minLedge = MIN(self.referenceBounds.size.width, rightLedge);
     rightLedge = MAX(rightLedge, minLedge);
     if (_viewAppeared && II_FLOAT_EQUAL(self.slidingControllerView.frame.origin.x, _rightLedge - self.referenceBounds.size.width)) {


### PR DESCRIPTION
Fixes a bug where compiling with LLVM and running on my iPhone 4S causes the center view to slide all the way off screen when swiping because "leftLedge" gets mistakenly set to 0.0.
