### PR TITLE
Fix memory error

### DIFF
--- a/ViewDeck/IIViewDeckController.m
+++ b/ViewDeck/IIViewDeckController.m
@@ -1146,11 +1146,11 @@
 
 - (void)setSlidingAndReferenceViews {
     if (self.navigationController && self.navigationControllerBehavior == IIViewDeckNavigationControllerIntegrated) {
-        _slidingController = self.navigationController;
+        _slidingController = II_RETAIN(self.navigationController);
         self.referenceView = [self.navigationController.view superview];
     }
     else {
-        _slidingController = self.centerController;
+        _slidingController = II_RETAIN(self.centerController);
         self.referenceView = self.view;
     }
 }


### PR DESCRIPTION
The slidingController property is defined as "retain" but is acting like "assign". Under low memory conditions after -cleanup gets called from -viewDidUnload, this causes a crash since II_RELEASE() reduces the retain count to 0 instead of 1.
