### PR TITLE
Resolve issue #30

### DIFF
--- a/ViewDeck/IIViewDeckController.m
+++ b/ViewDeck/IIViewDeckController.m
@@ -816,13 +816,6 @@
     if ([self.delegate respondsToSelector:@selector(viewDeckController:didPanToOffset:)])
         [self.delegate viewDeckController:self didPanToOffset:x];
 
-    if ((self.leftController.view.hidden && !leftWasHidden) || (self.rightController.view.hidden && !rightWasHidden)) {
-        [self centerViewVisible];
-    }
-    else if (leftWasHidden && rightWasHidden && (!self.leftController.view.hidden || !self.leftController.view.hidden)) {
-        [self centerViewHidden];
-    }
-
     if (panner.state == UIGestureRecognizerStateBegan) {
         if (x > 0) {
             [self checkDelegate:@selector(viewDeckControllerWillOpenLeftView:animated:) animated:NO];
@@ -833,6 +826,13 @@
     }
     
     if (panner.state == UIGestureRecognizerStateEnded) {    
+        if ((self.leftController.view.hidden && !leftWasHidden) || (self.rightController.view.hidden && !rightWasHidden)) {
+            [self centerViewVisible];
+        }
+        else if (leftWasHidden && rightWasHidden && (!self.leftController.view.hidden || !self.rightController.view.hidden)) {
+            [self centerViewHidden];
+        }
+
         CGFloat lw3 = (w-self.leftLedge) / 3.0;
         CGFloat rw3 = (w-self.rightLedge) / 3.0;
         CGFloat velocity = [panner velocityInView:self.referenceView].x;


### PR DESCRIPTION
This request is about issue #30.
First of all, this bug occur when `centerhiddenInteractivity` is set to `IIViewDeckCenterHiddenNotUserInteractiveWithTapToClose`

When the trigger for disabling user-interaction for centerView, the panningGestureRecognizer is detached. Because of that, panning gesture is not recognized anymore and this situation is occured(I mean like stucked with few pixel)

So I fix it by detaching PGR after UIGestureRecognizerStateEnded flag is set.

And  It's fine for right view because there was typo on the condition statement for disabling center-view.
I mean it was like below

``` objective-c
 else if (leftWasHidden && rightWasHidden && 
           (!self.leftController.view.hidden ||
            !self.leftController.view.hidden)) 
```

p.s. sorry for my poor english :-(
