### PR TITLE
Complete the show Center action

### DIFF
--- a/ViewDeck/IIViewDeckController.m
+++ b/ViewDeck/IIViewDeckController.m
@@ -563,10 +563,11 @@
 }
 
 - (void)showCenterView:(BOOL)animated  completion:(void(^)(IIViewDeckController* controller))completed {
-    if (!self.leftController.view.hidden) 
+    if (!self.leftController.view.hidden)
         [self closeLeftViewAnimated:animated completion:completed];
-    if (!self.rightController.view.hidden) 
+    else if (!self.rightController.view.hidden) 
         [self closeRightViewAnimated:animated completion:completed];
+    else completed(self);
 }
 
 - (void)toggleLeftView {


### PR DESCRIPTION
The complete block is not called when calling "showCenterView:completion:" when the center view is visible... I think it's better to call it even when the center view is currently visible.
