### PR TITLE
Fix for nil check infinite loop

### DIFF
--- a/ViewDeck/IIViewDeckController.m
+++ b/ViewDeck/IIViewDeckController.m
@@ -46,7 +46,7 @@
 #endif
 
 #define II_FLOAT_EQUAL(x, y) (((x) - (y)) == 0.0f)
-#define II_STRING_EQUAL(a, b) (a == nil && b == nil) || (a != nil && [a isEqualToString:b])
+#define II_STRING_EQUAL(a, b) ((a == nil && b == nil) || (a != nil && [a isEqualToString:b]))
 
 #define II_CGRectOffsetRightAndShrink(rect, offset)         \
   ({                                                        \


### PR DESCRIPTION
These lines:

IIViewDeckController.m:1078
if (![title isEqualToString:self.centerController.title]) self.centerController.title = title;

IIViewDeckController.m:1312
if (![[super title] isEqualToString:self.centerController.title]) {

can cause an infinite loop because they will always return true when the title is nil. The former will set the center controller's title, triggering the latter through the observer on the center controller's title, which will again trigger the former, repeat ad nauseum. I added a simple macro that also performs a nil check when checking for string equality.
