### PR TITLE
IIViewDeckController and subsequent viewcontrollers correctly deallocate.

### DIFF
--- a/ViewDeck/IIViewDeckController.m
+++ b/ViewDeck/IIViewDeckController.m
@@ -1393,7 +1393,7 @@ static const char* viewDeckControllerKey = "ViewDeckController";
 }
 
 - (void)setViewDeckController:(IIViewDeckController*)viewDeckController {
-    objc_setAssociatedObject(self, viewDeckControllerKey, viewDeckController, OBJC_ASSOCIATION_RETAIN);
+    objc_setAssociatedObject(self, viewDeckControllerKey, viewDeckController, OBJC_ASSOCIATION_ASSIGN);
 }
 
 - (void)vdc_presentModalViewController:(UIViewController *)modalViewController animated:(BOOL)animated {


### PR DESCRIPTION
Center/left/right viewcontrollers should not retain the viewDeckController.
