### PR TITLE
Make IIViewDeckController's delegate assign instead of retain

### DIFF
--- a/ViewDeck/IIViewDeckController.h
+++ b/ViewDeck/IIViewDeckController.h
@@ -66,7 +66,7 @@ typedef enum {
     CGFloat _preRotationWidth, _leftWidth, _rightWidth, _preRotationCenterWidth, _maxLedge, _offset;
 }
 
-@property (nonatomic, retain) id<IIViewDeckControllerDelegate> delegate;
+@property (nonatomic, assign) id<IIViewDeckControllerDelegate> delegate;
 @property (nonatomic, retain) UIViewController* centerController;
 @property (nonatomic, retain) UIViewController* leftController;
 @property (nonatomic, retain) UIViewController* rightController;


### PR DESCRIPTION
Having a retained delegate can be dangerous since the parent (delegate) generally owns the child (view deck controller) and thus creates a retain cycle. 

Someone explaining things better than I can: http://stackoverflow.com/questions/918698/why-are-objective-c-delegates-usually-given-the-property-assign-instead-of-retai
