### PR TITLE
Touches Still Blocked After Removing centerController

### DIFF
--- a/ViewDeck/IIViewDeckController.m
+++ b/ViewDeck/IIViewDeckController.m
@@ -296,7 +296,8 @@ __typeof__(h) __h = (h);                                    \
 #pragma mark - Bookkeeping
 
 - (NSArray*)controllers {
-    NSMutableArray* result = [NSMutableArray arrayWithObject:self.centerController];
+    NSMutableArray *result = [NSMutableArray array];
+    if (self.centerController) [result addObject:self.centerController];
     if (self.leftController) [result addObject:self.leftController];
     if (self.rightController) [result addObject:self.rightController];
     return [NSArray arrayWithArray:result];


### PR DESCRIPTION
1) After setting centerController to nil, touches are still blocked in the area where the ledge was because centerView is not being removed from the view hierarchy.

You can repro this as follows:
1. put UIButton on right side of left view
2. Instantiate IIViewDeckController with left and center controller
3. Set leftLedge so that it covers button
4. In code, set self.viewDeckController.centerController = nil
5. Button will not respond to touches because centerView is still there after center controller is removed

2) When centerController is nil, the controllers method on IIViewDeckController will throw an exception due to this line:

NSMutableArray\* result = [NSMutableArray arrayWithObject:self.centerController];

I saw this trying to dismiss a modal view controller with centerController set to nil. Here's the backtrace:
- thread #1: tid = 0x1c03, 0x3684e238 libobjc.A.dylib`objc_exception_throw, stop reason = breakpoint 1.1
  frame #0: 0x3684e238 libobjc.A.dylib`objc_exception_throw
  frame #1: 0x353799e8 CoreFoundation`-[__NSPlaceholderArray initWithObjects:count:] + 128
  frame #2: 0x3537be78 CoreFoundation`+[NSArray arrayWithObject:] + 44
  frame #3: 0x000680cc Vowchr`-[IIViewDeckController controllers] + 64 at IIViewDeckController.m:299
  frame #4: 0x0007046c Vowchr`-[IIViewDeckController performOffsetDelegate:offset:] + 268 at IIViewDeckController.m:1149
  frame #5: 0x00068e14 Vowchr`-[IIViewDeckController setSlidingFrameForOffset:] + 264 at IIViewDeckController.m:373
  frame #6: 0x0006a1fe Vowchr`-[IIViewDeckController viewWillAppear:] + 906 at IIViewDeckController.m:494
  frame #7: 0x32487d3c UIKit`-[UIViewController _setViewAppearState:isAnimating:] + 144
  frame #8: 0x324e1a56 UIKit`-[UIViewController beginAppearanceTransition:animated:] + 190
