### PR TITLE
Fixes a crash in LeftViewController.m

### DIFF
--- a/ViewDeckExample/LeftViewController.m
+++ b/ViewDeckExample/LeftViewController.m
@@ -151,7 +151,9 @@
         if ([controller.centerController isKindOfClass:[UINavigationController class]]) {
             UITableViewController* cc = (UITableViewController*)((UINavigationController*)controller.centerController).topViewController;
             cc.navigationItem.title = [tableView cellForRowAtIndexPath:indexPath].textLabel.text;
-            [cc.tableView deselectRowAtIndexPath:[cc.tableView indexPathForSelectedRow] animated:NO];
+            if ([cc respondsToSelector:@selector(tableView)]) {
+                [cc.tableView deselectRowAtIndexPath:[cc.tableView indexPathForSelectedRow] animated:NO];    
+            }
         }
         [NSThread sleepForTimeInterval:(300+arc4random()%700)/1000000.0]; // mimic delay... not really necessary
     }];


### PR DESCRIPTION
This is in the ViewDeckExample project.

After clicking the 'Center nav Controller' button in the right view controller the center view controller is changed to a NestViewController instance. However, when clicking on an item in the left view controller the app would crash because the left controller expects the center controller to inherit from UITableViewController, which is not the case.
