### PR TITLE
Additional panning mode

### DIFF
--- a/ViewDeck/IIViewDeckController.h
+++ b/ViewDeck/IIViewDeckController.h
@@ -31,7 +31,8 @@ typedef enum {
     IIViewDeckNoPanning,              // no panning allowed
     IIViewDeckFullViewPanning,        // the default: touch anywhere in the center view to drag the center view around
     IIViewDeckNavigationBarPanning,   // panning only occurs when you start touching in the navigation bar (when the center controller is a UINavigationController with a visible navigation bar). Otherwise it will behave as IIViewDeckNoPanning. 
-    IIViewDeckPanningViewPanning      // panning only occurs when you start touching in a UIView set in panningView property
+    IIViewDeckPanningViewPanning,      // panning only occurs when you start touching in a UIView set in panningView property
+    IIViewDeckConditionalPanning      //panning occurs when you start touching the navigation bar if the center controller is visible.  If the left or right controller is open, pannning occurs anywhere on the center controller, not just the navbar.    
 } IIViewDeckPanningMode;
 
 

--- a/ViewDeck/IIViewDeckController.m
+++ b/ViewDeck/IIViewDeckController.m
@@ -1255,6 +1255,28 @@ __typeof__(h) __h = (h);                                    \
             if (self.navigationController && !self.navigationController.navigationBarHidden) 
                 [self addPanner:self.navigationController.navigationBar];
             break;
+
+        case IIViewDeckConditionalPanning:
+            // add the navbar no matter what
+            if (self.navigationController && !self.navigationController.navigationBarHidden) {
+                [self addPanner:self.navigationController.navigationBar];
+            }
+            
+            if (self.centerController.navigationController && !self.centerController.navigationController.navigationBarHidden) {
+                [self addPanner:self.centerController.navigationController.navigationBar];
+            }
+            
+            if ([self.centerController isKindOfClass:[UINavigationController class]] && !((UINavigationController*)self.centerController).navigationBarHidden) {
+                [self addPanner:((UINavigationController*)self.centerController).navigationBar];
+            }
+            
+            // if a panel is open, add allow the center to pan
+            if ([self leftControllerIsOpen] || [self rightControllerIsOpen])
+                [self addPanner:self.slidingControllerView];
+            // also add to disabled center
+            if (self.centerTapper)
+                [self addPanner:self.centerTapper];
+            break;
             
         case IIViewDeckNavigationBarPanning:
             if (self.navigationController && !self.navigationController.navigationBarHidden) {


### PR DESCRIPTION
We wanted to have the ability to only slide back to the center controller with a gesture or tap when a left or right panel is open - otherwise use the navbar.  This could probably be done more elegantly, but I thought I'd go ahead and send a pull request.  I work for CrowdCompass and we're using your viewDeckController in our app.  Beautiful code!  I'm just getting started with iOS development, and reading through your code for this project has been beneficial!
