### PR TITLE
Remove unused variables and remove compiler warning

### DIFF
--- a/ViewDeck/IIViewDeckController.m
+++ b/ViewDeck/IIViewDeckController.m
@@ -1270,9 +1270,6 @@ __typeof__(h) __h = (h);                                    \
     
     [self setSlidingFrameForOffset:x];
     
-    BOOL rightWasHidden = self.rightController.view.hidden;
-    BOOL leftWasHidden = self.leftController.view.hidden;
-    
     [self performOffsetDelegate:@selector(viewDeckController:didPanToOffset:) offset:x];
     
     if (panner.state == UIGestureRecognizerStateEnded) {


### PR DESCRIPTION
Remove 2 unused variables that are no longer in use. Gets rid of compiler warning.
