### PR TITLE
Added compatibility for UIAppearance protocol

### DIFF
--- a/ViewDeck/IIViewDeckController.m
+++ b/ViewDeck/IIViewDeckController.m
@@ -1729,6 +1729,9 @@ inline IIViewDeckOffsetOrientation IIViewDeckOffsetOrientationFromIIViewDeckSide
     [self removePanners];
     if (!self.centerTapper) {
         self.centerTapper = [UIButton buttonWithType:UIButtonTypeCustom];
+        [self.centerTapper setBackgroundImage:nil forState:UIControlStateNormal];
+        [self.centerTapper setBackgroundImage:nil forState:UIControlStateHighlighted];
+        [self.centerTapper setBackgroundImage:nil forState:UIControlStateDisabled];
         self.centerTapper.autoresizingMask = UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight;
         self.centerTapper.frame = [self.centerView bounds];
         [self.centerTapper addTarget:self action:@selector(centerTapped) forControlEvents:UIControlEventTouchUpInside];


### PR DESCRIPTION
I noticed a bug where if you are using the UIAppearance protocol to set UIButton background images, the center controller would be overlaid with those images when one of the side views is open (and the ViewDeckController's centerhiddenInteractivity is set to IIViewDeckCenterHiddenNotUserInteractiveWithTapToClose or IIViewDeckCenterHiddenNotUserInteractiveWithTapToCloseBouncing ). This explicitly sets the background images for the UIButton used by the ViewDeckController in those states to nil so the button is transparent and does not obscure the center controller.
