### PR TITLE
corrected typo with isSideOpen and isSideClosed

### DIFF
--- a/ViewDeck/IIViewDeckController.h
+++ b/ViewDeck/IIViewDeckController.h
@@ -219,8 +219,8 @@ typedef void (^IIViewDeckControllerBounceBlock) (IIViewDeckController *controlle
 - (BOOL)canRightViewPushViewControllerOverCenterController;
 - (void)rightViewPushViewControllerOverCenterController:(UIViewController*)controller;
 
-- (BOOL)isSideClosed:(IIViewDeckSide)viewDeckSize;
-- (BOOL)isSideOpen:(IIViewDeckSide)viewDeckSize;
+- (BOOL)isSideClosed:(IIViewDeckSide)viewDeckSide;
+- (BOOL)isSideOpen:(IIViewDeckSide)viewDeckSide;
 
 - (CGFloat)statusBarHeight;
 

--- a/ViewDeck/IIViewDeckController.m
+++ b/ViewDeck/IIViewDeckController.m
@@ -1105,11 +1105,11 @@ inline IIViewDeckOffsetOrientation IIViewDeckOffsetOrientationFromIIViewDeckSide
 
 #pragma mark - controller state
 
-- (BOOL)isSideClosed:(IIViewDeckSide)viewDeckSize {
-    if (![self controllerForSide:viewDeckSize])
+- (BOOL)isSideClosed:(IIViewDeckSide)viewDeckSide {
+    if (![self controllerForSide:viewDeckSide])
         return YES;
     
-    switch (viewDeckSize) {
+    switch (viewDeckSide) {
         case IIViewDeckLeftSide:
             return CGRectGetMinX(self.slidingControllerView.frame) <= 0;
             
@@ -1128,11 +1128,11 @@ inline IIViewDeckOffsetOrientation IIViewDeckOffsetOrientationFromIIViewDeckSide
 }
 
 
-- (BOOL)isSideOpen:(IIViewDeckSide)viewDeckSize {
-    if (![self controllerForSide:viewDeckSize])
+- (BOOL)isSideOpen:(IIViewDeckSide)viewDeckSide {
+    if (![self controllerForSide:viewDeckSide])
         return NO;
     
-    switch (viewDeckSize) {
+    switch (viewDeckSide) {
         case IIViewDeckLeftSide:
             return II_FLOAT_EQUAL(CGRectGetMinX(self.slidingControllerView.frame), self.referenceBounds.size.width - _ledge[IIViewDeckLeftSide]);
             


### PR DESCRIPTION
Great library. I just noticed a small typo with the isSideOpen and isSideClosed methods in your development branch. You are referring to 'side' instead of 'size' correct?
