### PR TITLE
Adding delegate method viewDeckControllerGestureRecognizerShouldBegin:

### DIFF
--- a/ViewDeck/IIViewDeckController.h
+++ b/ViewDeck/IIViewDeckController.h
@@ -172,6 +172,7 @@ typedef void (^IIViewDeckControllerBlock) (IIViewDeckController *controller);
 - (BOOL)viewDeckControllerWillCloseRightView:(IIViewDeckController*)viewDeckController animated:(BOOL)animated;
 - (void)viewDeckControllerDidCloseRightView:(IIViewDeckController*)viewDeckController animated:(BOOL)animated;
 - (void)viewDeckControllerDidShowCenterView:(IIViewDeckController*)viewDeckController animated:(BOOL)animated;
+- (BOOL)viewDeckControllerGestureRecognizerShouldBegin:(IIViewDeckController *)viewDeckController;
 
 @end
 

--- a/ViewDeck/IIViewDeckController.m
+++ b/ViewDeck/IIViewDeckController.m
@@ -1306,6 +1306,11 @@ __typeof__(h) __h = (h);                                    \
 #pragma mark - Panning
 
 - (BOOL)gestureRecognizerShouldBegin:(UIGestureRecognizer *)gestureRecognizer {
+    if (self.delegate && [self.delegate respondsToSelector:@selector(viewDeckControllerGestureRecognizerShouldBegin:)]) {
+        if ([self.delegate viewDeckControllerGestureRecognizerShouldBegin:self] == NO) {
+            return NO;
+        }
+    }
     if (self.panningGestureDelegate && [self.panningGestureDelegate respondsToSelector:@selector(gestureRecognizerShouldBegin:)]) {
         BOOL result = [self.panningGestureDelegate gestureRecognizerShouldBegin:gestureRecognizer];
         if (!result) return result;


### PR DESCRIPTION
This is useful to block the gesture recognizer for table views in editing state.
