### PR TITLE
Velocity of swipe open/close animations matches gesture speed.

### DIFF
--- a/ViewDeck/IIViewDeckController.h
+++ b/ViewDeck/IIViewDeckController.h
@@ -161,6 +161,7 @@ typedef void (^IIViewDeckControllerBounceBlock) (IIViewDeckController *controlle
 - (BOOL)openLeftViewBouncing:(IIViewDeckControllerBounceBlock)bounced completion:(IIViewDeckControllerBlock)completed;
 - (BOOL)closeLeftViewAnimated:(BOOL)animated;
 - (BOOL)closeLeftViewAnimated:(BOOL)animated completion:(IIViewDeckControllerBlock)completed;
+- (BOOL)closeLeftViewAnimated:(BOOL)animated duration:(NSTimeInterval)duration completion:(IIViewDeckControllerBlock)completed;
 - (BOOL)closeLeftViewBouncing:(IIViewDeckControllerBounceBlock)bounced;
 - (BOOL)closeLeftViewBouncing:(IIViewDeckControllerBounceBlock)bounced completion:(IIViewDeckControllerBlock)completed;
 
@@ -175,6 +176,7 @@ typedef void (^IIViewDeckControllerBounceBlock) (IIViewDeckController *controlle
 - (BOOL)openRightViewBouncing:(IIViewDeckControllerBounceBlock)bounced completion:(IIViewDeckControllerBlock)completed;
 - (BOOL)closeRightViewAnimated:(BOOL)animated;
 - (BOOL)closeRightViewAnimated:(BOOL)animated completion:(IIViewDeckControllerBlock)completed;
+- (BOOL)closeRightViewAnimated:(BOOL)animated duration:(NSTimeInterval)duration completion:(IIViewDeckControllerBlock)completed;
 - (BOOL)closeRightViewBouncing:(IIViewDeckControllerBounceBlock)bounced;
 - (BOOL)closeRightViewBouncing:(IIViewDeckControllerBounceBlock)bounced completion:(IIViewDeckControllerBlock)completed;
 
@@ -189,6 +191,7 @@ typedef void (^IIViewDeckControllerBounceBlock) (IIViewDeckController *controlle
 - (BOOL)openTopViewBouncing:(IIViewDeckControllerBounceBlock)bounced completion:(IIViewDeckControllerBlock)completed;
 - (BOOL)closeTopViewAnimated:(BOOL)animated;
 - (BOOL)closeTopViewAnimated:(BOOL)animated completion:(IIViewDeckControllerBlock)completed;
+- (BOOL)closeTopViewAnimated:(BOOL)animated duration:(NSTimeInterval)duration completion:(IIViewDeckControllerBlock)completed;
 - (BOOL)closeTopViewBouncing:(IIViewDeckControllerBounceBlock)bounced;
 - (BOOL)closeTopViewBouncing:(IIViewDeckControllerBounceBlock)bounced completion:(IIViewDeckControllerBlock)completed;
 
@@ -203,6 +206,7 @@ typedef void (^IIViewDeckControllerBounceBlock) (IIViewDeckController *controlle
 - (BOOL)openBottomViewBouncing:(IIViewDeckControllerBounceBlock)bounced completion:(IIViewDeckControllerBlock)completed;
 - (BOOL)closeBottomViewAnimated:(BOOL)animated;
 - (BOOL)closeBottomViewAnimated:(BOOL)animated completion:(IIViewDeckControllerBlock)completed;
+- (BOOL)closeBottomViewAnimated:(BOOL)animated duration:(NSTimeInterval)duration completion:(IIViewDeckControllerBlock)completed;
 - (BOOL)closeBottomViewBouncing:(IIViewDeckControllerBounceBlock)bounced;
 - (BOOL)closeBottomViewBouncing:(IIViewDeckControllerBounceBlock)bounced completion:(IIViewDeckControllerBlock)completed;
 
@@ -213,6 +217,7 @@ typedef void (^IIViewDeckControllerBounceBlock) (IIViewDeckController *controlle
 - (BOOL)closeOpenView;
 - (BOOL)closeOpenViewAnimated:(BOOL)animated;
 - (BOOL)closeOpenViewAnimated:(BOOL)animated completion:(IIViewDeckControllerBlock)completed;
+- (BOOL)closeOpenViewAnimated:(BOOL)animated duration:(NSTimeInterval)duration completion:(IIViewDeckControllerBlock)completed;
 - (BOOL)closeOpenViewBouncing:(IIViewDeckControllerBounceBlock)bounced;
 - (BOOL)closeOpenViewBouncing:(IIViewDeckControllerBounceBlock)bounced completion:(IIViewDeckControllerBlock)completed;
 


### PR DESCRIPTION
Hi,

This patch improves the ViewDeck swipe open/close animations so that the velocity of the animation after swiping now more closely matches the user's swipe velocity.

i.e. if you swipe (or drag & release) quickly, the ViewDeck will open/close quickly. If you swipe/drag slowly, the ViewDeck will animate slowly. The animation speed is calculated to closely match the gesture velocity, with some min/max thresholds enforced to keep animation speeds sensible.

This animation behaviour is fairly subtle, but improves the quality of the ViewDeck. Compare old/new behaviour side-by-side to appreciate the difference. We've been running this in production for a few months now, it works nicely.

Let me know if you find any issues with it.

Cheers,
Chris
