### PR TITLE
Fixed Compiler warning due to NSKeyValueChangeSetting key

### DIFF
--- a/ViewDeck/IIViewDeckController.m
+++ b/ViewDeck/IIViewDeckController.m
@@ -731,7 +731,7 @@ inline IIViewDeckOffsetOrientation IIViewDeckOffsetOrientationFromIIViewDeckSide
 - (void)viewWillAppear:(BOOL)animated {
     [super viewWillAppear:animated];
     
-    [self.view addObserver:self forKeyPath:@"bounds" options:NSKeyValueChangeSetting context:nil];
+    [self.view addObserver:self forKeyPath:@"bounds" options:NSKeyValueObservingOptionNew context:nil];
 
     if (!_viewFirstAppeared) {
         _viewFirstAppeared = YES;


### PR DESCRIPTION
Fixed this error:

```
IIViewDeckController.m:571:62: warning: implicit conversion from enumeration type 'enum NSKeyValueChange' to different enumeration type 'NSKeyValueObservingOptions' (aka 'enum NSKeyValueObservingOptions') [-Wconversion]
[self.view addObserver:self forKeyPath:@"bounds" options:NSKeyValueChangeSetting context:nil];
```
