### PR TITLE
Added support for new iOS 6 appearance method forwarding

### DIFF
--- a/ViewDeck/WrapController.m
+++ b/ViewDeck/WrapController.m
@@ -125,7 +125,16 @@
 #endif
 }
 
+// Deprecated since iOS 6
 - (BOOL)automaticallyForwardAppearanceAndRotationMethodsToChildViewControllers {
+    return NO;
+}
+
+- (BOOL)shouldAutomaticallyForwardAppearanceMethods {
+    return NO;
+}
+
+- (BOOL)shouldAutomaticallyForwardRotationMethods {
     return NO;
 }
 


### PR DESCRIPTION
iOS 6 introduced two new appearance and rotation forwarding methods on UIViewController and deprecated `automaticallyForwardAppearanceAndRotationMethodsToChildViewControllers`. The two new methods that replace it are:
- `shouldAutomaticallyForwardAppearanceMethods` and
- `shouldAutomaticallyForwardRotationMethods`

This commit should make the code work correctly on iOS 6 and prevent duplicate invocations of appearance/rotation methods.

Signed-off-by: Chris Brauchli cbrauchli@gmail.com
