### PR TITLE
Link NavigationExample with QuartzCore.framework.

### DIFF
--- a/NavigationExample/NavigationExample.xcodeproj/project.pbxproj
+++ b/NavigationExample/NavigationExample.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		3EC5C5191671F7A900B3766D /* QuartzCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3EC5C5181671F7A900B3766D /* QuartzCore.framework */; };
 		E27E514B15726C9F009D90EB /* UIKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E27E514A15726C9F009D90EB /* UIKit.framework */; };
 		E27E514D15726C9F009D90EB /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E27E514C15726C9F009D90EB /* Foundation.framework */; };
 		E27E514F15726C9F009D90EB /* CoreGraphics.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E27E514E15726C9F009D90EB /* CoreGraphics.framework */; };
@@ -29,6 +30,7 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
+		3EC5C5181671F7A900B3766D /* QuartzCore.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = QuartzCore.framework; path = System/Library/Frameworks/QuartzCore.framework; sourceTree = SDKROOT; };
 		E27E514615726C9F009D90EB /* NavigationExample.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = NavigationExample.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		E27E514A15726C9F009D90EB /* UIKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = UIKit.framework; path = System/Library/Frameworks/UIKit.framework; sourceTree = SDKROOT; };
 		E27E514C15726C9F009D90EB /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = System/Library/Frameworks/Foundation.framework; sourceTree = SDKROOT; };
@@ -66,6 +68,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				3EC5C5191671F7A900B3766D /* QuartzCore.framework in Frameworks */,
 				E2CA7FBF1576DEFD00408061 /* MessageUI.framework in Frameworks */,
 				E27E514B15726C9F009D90EB /* UIKit.framework in Frameworks */,
 				E27E514D15726C9F009D90EB /* Foundation.framework in Frameworks */,
@@ -79,6 +82,7 @@
 		E27E513B15726C9F009D90EB = {
 			isa = PBXGroup;
 			children = (
+				3EC5C5181671F7A900B3766D /* QuartzCore.framework */,
 				E27E515015726C9F009D90EB /* NavigationExample */,
 				E27E514915726C9F009D90EB /* Frameworks */,
 				E27E514715726C9F009D90EB /* Products */,


### PR DESCRIPTION
The NavigationExample was not compiling, it needs to be linked with the QuartzCore framework.
