### PR TITLE
Fixing docs for view deck sizeMode / rotation behavior in develop.

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,14 +125,14 @@ Of course, you can turn this behavior off. Just set `elasticity = NO` when loadi
 ## rotation
 
 The controller fully supports view rotation. If the center controller is set, it will control the possible interface rotation. If no center controller is set, all interface rotations are allowed.
-When rotating, the controller will move the open center views to the correct location: the ledge will be the same before and after rotation (this means a different part of the underlying side view will be exposed). You can control this behavior through the `rotationBehavior` property. You can use one of the following values:
+When rotating, the controller will move the open center views to the correct location: the ledge will be the same before and after rotation (this means a different part of the underlying side view will be exposed). You can control this behavior through the `sizeMode` property. You can use one of the following values:
 
-    typedef enum {
-        IIViewDeckRotationKeepsLedgeSizes, // when rotating, the ledge sizes are kept (side views are more/less visible)
-        IIViewDeckRotationKeepsViewSizes  // when rotating, the size view sizes are kept (ledges change)
-    } IIViewDeckRotationBehavior;
+    typdef enum {
+        IIViewDeckLedgeSizeMode, // when rotating, the ledge sizes are kept (side views are more/less visible)
+        IIViewDeckViewSizeMode  // when rotating, the size view sizes are kept (ledges change)
+    } IIViewDeckSizeMode;
 
-The default is `IIViewDeckRotationKeepsLedgeSizes`, which keeps the sizes of the defined ledges the same when rotating.
+The default is `IIViewDeckLedgeSizeMode`, which keeps the sizes of the defined ledges the same when rotating.
 
 ## panning
 


### PR DESCRIPTION
The documentation hadn't yet been updated to reflect some of the naming changes around ledge sizes and rotation behavior, so this fixes that.
