### PR TITLE
Control independently if left or right opening gestures are enabled

### DIFF
--- a/ViewDeck/IIViewDeckController.h
+++ b/ViewDeck/IIViewDeckController.h
@@ -89,6 +89,9 @@ typedef void (^IIViewDeckControllerBlock) (IIViewDeckController *controller);
 @property (nonatomic) IIViewDeckRotationBehavior rotationBehavior;
 @property (nonatomic) BOOL automaticallyUpdateTabBarItems;
 
+@property (nonatomic) BOOL disableLeftOpeningGesture;
+@property (nonatomic) BOOL disableRightOpeningGesture;
+
 - (id)initWithCenterViewController:(UIViewController*)centerController;
 - (id)initWithCenterViewController:(UIViewController*)centerController leftViewController:(UIViewController*)leftController;
 - (id)initWithCenterViewController:(UIViewController*)centerController rightViewController:(UIViewController*)rightController;

--- a/ViewDeck/IIViewDeckController.m
+++ b/ViewDeck/IIViewDeckController.m
@@ -208,6 +208,9 @@ __typeof__(h) __h = (h);                                    \
 @synthesize elastic = _elastic;
 @synthesize automaticallyUpdateTabBarItems = _automaticallyUpdateTabBarItems;
 @synthesize panningGestureDelegate = _panningGestureDelegate;
+@synthesize disableLeftOpeningGesture = _disableLeftOpeningGesture;
+@synthesize disableRightOpeningGesture = _disableRightOpeningGesture;
+
 
 #pragma mark - Initalisation and deallocation
 
@@ -246,6 +249,9 @@ __typeof__(h) __h = (h);                                    \
         self.rightController = nil;
         self.leftLedge = 44;
         self.rightLedge = 44;
+        
+        _disableLeftOpeningGesture = NO;
+        _disableRightOpeningGesture = NO;
     }
     return self;
 }
@@ -1318,12 +1324,12 @@ __typeof__(h) __h = (h);                                    \
     BOOL ok =  YES;
 
     if (x > 0) {
-        ok = [self checkDelegate:@selector(viewDeckControllerWillOpenLeftView:animated:) animated:NO];
+        ok = !self.disableLeftOpeningGesture && [self checkDelegate:@selector(viewDeckControllerWillOpenLeftView:animated:) animated:NO];
         if (!ok)
             [self closeLeftViewAnimated:NO];
     }
     else if (x < 0) {
-        ok = [self checkDelegate:@selector(viewDeckControllerWillOpenRightView:animated:) animated:NO];
+        ok = !self.disableRightOpeningGesture && [self checkDelegate:@selector(viewDeckControllerWillOpenRightView:animated:) animated:NO];
         if (!ok)
             [self closeRightViewAnimated:NO];
     }
@@ -1399,7 +1405,7 @@ __typeof__(h) __h = (h);                                    \
         }
 
         if (x > 0) {
-            BOOL canOpen = [self checkDelegate:@selector(viewDeckControllerWillOpenLeftView:animated:) animated:NO];
+            BOOL canOpen = !self.disableLeftOpeningGesture && [self checkDelegate:@selector(viewDeckControllerWillOpenLeftView:animated:) animated:NO];
             didOpenSelector = @selector(viewDeckControllerDidOpenLeftView:animated:);
             if (!canOpen) {
                 [self closeRightViewAnimated:NO];
@@ -1417,7 +1423,7 @@ __typeof__(h) __h = (h);                                    \
         }
 
         if (x < 0) {
-            BOOL canOpen = [self checkDelegate:@selector(viewDeckControllerWillOpenRightView:animated:) animated:NO];
+            BOOL canOpen = !self.disableRightOpeningGesture && [self checkDelegate:@selector(viewDeckControllerWillOpenRightView:animated:) animated:NO];
             didOpenSelector = @selector(viewDeckControllerDidOpenRightView:animated:);
             if (!canOpen) {
                 [self closeLeftViewAnimated:NO];


### PR DESCRIPTION
Adding two boolean to control independently if left or right opening gestures are enabled

I've the case that I've left and right controllers, and in some conditions I don't want the one of both view accessible through the gesture.
Due to animation I can't nil rightViewController and I don't want to remove the other gesture
Hope it makes sense.
