### PR TITLE
Add panners when switching the center controller

### DIFF
--- a/ViewDeck/IIViewDeckController.m
+++ b/ViewDeck/IIViewDeckController.m
@@ -2512,7 +2512,12 @@ static NSTimeInterval durationToAnimate(CGFloat pointsToAnimate, CGFloat velocit
         
         afterBlock(_centerController);
         [_centerController didMoveToParentViewController:self];
-    }    
+        
+        if ([self isAnySideOpen]) {
+            [self centerViewHidden];
+        }
+
+    }
 }
 
 - (void)setAutomaticallyUpdateTabBarItems:(BOOL)automaticallyUpdateTabBarItems {


### PR DESCRIPTION
When the center controller is hidden and we change it (like in the main / detail split view concept), the panner should be added if needed.

Not sure if it's the best place to do it though
