### PR TITLE
Fixed infinite recursion on iOS 4 

### DIFF
--- a/ViewDeck/IIViewDeckController.m
+++ b/ViewDeck/IIViewDeckController.m
@@ -919,7 +919,7 @@ static NSTimeInterval durationToAnimate(CGFloat pointsToAnimate, CGFloat velocit
 {
     _preRotationSize = self.referenceBounds.size;
     _preRotationCenterSize = self.centerView.bounds.size;
-    _preRotationIsLandscape = UIInterfaceOrientationIsLandscape(self.interfaceOrientation);
+    _preRotationIsLandscape = UIInterfaceOrientationIsLandscape([UIApplication sharedApplication].statusBarOrientation);
     _willAppearShouldArrangeViewsAfterRotation = interfaceOrientation;
     
     // give other controllers a chance to act on it too


### PR DESCRIPTION
I solved this issue by assigning the **_preRotationIsLandscape** variable in the **shouldAutorotateToInterfaceOrientation** method with:
`_preRotationIsLandscape = UIInterfaceOrientationIsLandscape([UIApplication sharedApplication].statusBarOrientation);`

This is working fine on iOS 4.3, 5.0, & 6.0.
