### PR TITLE
Removed unused variable

### DIFF
--- a/ViewDeck/IIViewDeckController.h
+++ b/ViewDeck/IIViewDeckController.h
@@ -91,7 +91,7 @@ extern IIViewDeckOffsetOrientation IIViewDeckOffsetOrientationFromIIViewDeckSide
 @private    
     CGPoint _panOrigin;
     UInt32 _viewAppeared;
-    BOOL _viewFirstAppeared, _shouldViewDidAppear;
+    BOOL _viewFirstAppeared;
     UInt32 _sideAppeared[6];
     CGFloat _ledge[5];
     UIViewController* _controllers[6];


### PR DESCRIPTION
The **_shouldViewDidAppear** variable was removed from the source code in commit 805d272cc6716ab2dd8c62618836a4e4ffdddc19, but the declaration remained in the header.  This code change removes the unused variable.
