### PR TITLE
Mid-bounce panning fix

### DIFF
--- a/ViewDeck/IIViewDeckController.m
+++ b/ViewDeck/IIViewDeckController.m
@@ -2267,7 +2267,17 @@ static NSTimeInterval durationToAnimate(CGFloat pointsToAnimate, CGFloat velocit
         }
     }
     
-    [self panToSlidingFrameForOffset:v forOrientation:orientation];
+    // Check for an in-flight bounce animation
+    CAKeyframeAnimation *bounceAnimation = (CAKeyframeAnimation *)[self.slidingControllerView.layer animationForKey:@"previewBounceAnimation"];
+    if (bounceAnimation != nil) {
+        self.slidingControllerView.frame = [[self.slidingControllerView.layer presentationLayer] frame];
+        [self.slidingControllerView.layer removeAnimationForKey:@"previewBounceAnimation"];
+        [UIView animateWithDuration:0.3 delay:0 options:UIViewAnimationOptionLayoutSubviews | UIViewAnimationOptionBeginFromCurrentState animations:^{
+            [self panToSlidingFrameForOffset:v forOrientation:orientation];
+        } completion:nil];
+    } else {
+        [self panToSlidingFrameForOffset:v forOrientation:orientation];
+    }
     
     if (panner.state == UIGestureRecognizerStateEnded ||
         panner.state == UIGestureRecognizerStateCancelled ||


### PR DESCRIPTION
Looks like I left this out when I upgraded the preview bounce stuff to 2.0 a few months ago (it was in 1.4, though). This prevents the sliding view from jumping around if the user decides to pan the view before the bounce animation has completed.
