### PR TITLE
Allow UIKit managing the appearance methods

### DIFF
--- a/ViewDeck/IIViewDeckController.m
+++ b/ViewDeck/IIViewDeckController.m
@@ -88,6 +88,7 @@ __typeof__(h) __h = (h);                                    \
 #import <objc/message.h>
 #import "IIWrapController.h"
 
+
 enum {
     IIViewDeckNoSide = 0,
     IIViewDeckCenterSide = 5,
@@ -145,6 +146,14 @@ static NSTimeInterval durationToAnimate(CGFloat pointsToAnimate, CGFloat velocit
 }
 
 #define DEFAULT_DURATION 0.0
+
+@interface UIViewController (UIViewDeckController_ViewContainmentEmulation_Fakes)
+- (void)vdc_addChildViewController:(UIViewController *)childController;
+- (void)vdc_removeFromParentViewController;
+- (void)vdc_willMoveToParentViewController:(UIViewController *)parent;
+- (void)vdc_didMoveToParentViewController:(UIViewController *)parent;
+@end
+
 
 @interface IIViewDeckController () <UIGestureRecognizerDelegate>
 
@@ -1167,7 +1176,7 @@ static NSTimeInterval durationToAnimate(CGFloat pointsToAnimate, CGFloat velocit
 }
 
 - (BOOL)checkCanCloseSide:(IIViewDeckSide)viewDeckSide {
-    return ![self isSideClosed:viewDeckSide] && [self checkDelegate:@selector(viewDeckController:shouldCloseViewSide:) side:viewDeckSide];
+    return ![self isSideClosed:viewDeckSide] && [self checkDelegate:@selector(viewDeckController:shouldCloseViewSide:animated:) side:viewDeckSide];
 }
 
 - (void)notifyWillOpenSide:(IIViewDeckSide)viewDeckSide animated:(BOOL)animated {
@@ -1880,7 +1889,7 @@ static NSTimeInterval durationToAnimate(CGFloat pointsToAnimate, CGFloat velocit
         
         // perform completion and delegate call
         if (completed) completed(self, YES);
-        if (callDelegate) [self performDelegate:@selector(viewDeckController:didPreviewBounceViewSide:) side:viewDeckSide animated:YES];
+        if (callDelegate) [self performDelegate:@selector(viewDeckController:didPreviewBounceViewSide:animated:) side:viewDeckSide animated:YES];
     }];
     [self.slidingControllerView.layer addAnimation:animation forKey:@"previewBounceAnimation"];
     


### PR DESCRIPTION
By creating a subclass of `IIViewDeckController` and overriding the method `- (BOOL)shouldAutomaticallyForwardAppearanceMethods` to set it to `YES`, it allows UIKit to manage the appearance methods of child view controllers.

By default, `IIViewDeckController` controls the appearance methods but the problem is that the appearance methods are not called on child view controllers of view controllers controlled by `IIViewDeckController`.

Like it's shown in this [sample code](https://github.com/benoitsan/ViewDeckExample), appearance methods are called on `BBChildCenterViewController` which is a child view controller of `BBChildCenterViewController`.
