### PR TITLE
Added orientation support when centerViewController is a subclass of UINavigationViewController

### DIFF
--- a/ViewDeck/IIViewDeckController.m
+++ b/ViewDeck/IIViewDeckController.m
@@ -908,11 +908,29 @@ static NSTimeInterval durationToAnimate(CGFloat pointsToAnimate, CGFloat velocit
     return [super supportedInterfaceOrientations];
 }
 
-- (UIInterfaceOrientation)preferredInterfaceOrientationForPresentation {
-    if (self.centerController)
-        return [self.centerController preferredInterfaceOrientationForPresentation];
+- (UIInterfaceOrientation)preferredInterfaceOrientationForPresentation
+{
+    // default values
+    UIInterfaceOrientation preferedOrientation = [super preferredInterfaceOrientationForPresentation];
     
-    return [super preferredInterfaceOrientationForPresentation];
+    // get orientation
+    if (self.centerController)
+    {
+        // UINavigationController support
+        if ([self.centerController isKindOfClass:UINavigationController.class]) {
+            NSArray *vcList = [(id)self.centerController viewControllers];
+            if (vcList && vcList.count) {
+                id lastVc = [vcList lastObject];
+                if (lastVc) {
+                    preferedOrientation = [lastVc preferredInterfaceOrientationForPresentation];
+                }
+            }
+        } else {
+            preferedOrientation = [self.centerController preferredInterfaceOrientationForPresentation];
+        }
+    }
+    
+    return preferedOrientation;
 }
 
 - (BOOL)shouldAutorotateToInterfaceOrientation:(UIInterfaceOrientation)interfaceOrientation
@@ -926,8 +944,28 @@ static NSTimeInterval durationToAnimate(CGFloat pointsToAnimate, CGFloat velocit
     [self relayRotationMethod:^(UIViewController *controller) {
         [controller shouldAutorotateToInterfaceOrientation:interfaceOrientation];
     }];
-
-    return !self.centerController || [self.centerController shouldAutorotateToInterfaceOrientation:interfaceOrientation];
+    
+    
+    BOOL shouldAutorotate = NO;
+    
+    if (self.centerController)
+    {
+        // UINavigationController support
+        if ([self.centerController isKindOfClass:UINavigationController.class])
+        {
+            NSArray *vcList = [(id)self.centerController viewControllers];
+            if (vcList && vcList.count) {
+                id lastVc = [vcList lastObject];
+                if (lastVc) {
+                    shouldAutorotate = [lastVc shouldAutorotateToInterfaceOrientation:interfaceOrientation];
+                }
+            }
+        } else {
+            shouldAutorotate = [self.centerController shouldAutorotateToInterfaceOrientation:interfaceOrientation];
+        }
+    }
+    
+    return shouldAutorotate;
 }
 
 - (void)willAnimateRotationToInterfaceOrientation:(UIInterfaceOrientation)toInterfaceOrientation duration:(NSTimeInterval)duration {


### PR DESCRIPTION
Hi,

I have added orientation support when centerViewController is a subclass of UINavigationViewController.
In my project I use a UINavigationViewController for my centerController. Because of that the controller does not receive any rotation changes as I have not subclassed UINavigationController.
When I present a modalViewController on the centerController and want to only rotate this modalViewController, I need to prevent the rotation in the centerViewController.
I have checked the proper behaviour in iOS 5.1 and iOS 6.1. I can't test it on iOS 4.3.

This was the previous call:
[self.centerController preferredInterfaceOrientationForPresentation];

greetings,
Steven
