### PR TITLE
Added support for weak delegate pointers (for SDK and compilers that support them).

### DIFF
--- a/ViewDeck/IIViewDeckController.h
+++ b/ViewDeck/IIViewDeckController.h
@@ -25,6 +25,29 @@
 
 #import <UIKit/UIKit.h>
 
+// thanks to http://stackoverflow.com/a/8594878/742176
+
+#if TARGET_OS_IPHONE && defined(__IPHONE_5_0) && (__IPHONE_OS_VERSION_MIN_REQUIRED >= __IPHONE_5_0) && __clang__ && (__clang_major__ >= 3)
+#define II_SDK_SUPPORTS_WEAK 1
+#elif TARGET_OS_MAC && defined(__MAC_10_7) && (MAC_OS_X_VERSION_MIN_REQUIRED >= __MAC_10_7) && __clang__ && (__clang_major__ >= 3)
+#define II_SDK_SUPPORTS_WEAK 1
+#else
+#define II_SDK_SUPPORTS_WEAK 0
+#endif
+
+#if II_SDK_SUPPORTS_WEAK
+#define __ii_weak        __weak
+#define ii_weak_property weak
+#else
+#if __clang__ && (__clang_major__ >= 3)
+#define __ii_weak __unsafe_unretained
+#else
+#define __ii_weak
+#endif
+#define ii_weak_property assign
+#endif
+
+
 @protocol IIViewDeckControllerDelegate;
 
 enum {
@@ -105,7 +128,7 @@ extern IIViewDeckOffsetOrientation IIViewDeckOffsetOrientationFromIIViewDeckSide
 typedef void (^IIViewDeckControllerBlock) (IIViewDeckController *controller, BOOL success);
 typedef void (^IIViewDeckControllerBounceBlock) (IIViewDeckController *controller);
 
-@property (nonatomic, assign) id<IIViewDeckControllerDelegate> delegate;
+@property (nonatomic, ii_weak_property) __ii_weak id<IIViewDeckControllerDelegate> delegate;
 @property (nonatomic, assign) IIViewDeckDelegateMode delegateMode;
 
 @property (nonatomic, readonly, retain) NSArray* controllers;
@@ -117,7 +140,7 @@ typedef void (^IIViewDeckControllerBounceBlock) (IIViewDeckController *controlle
 @property (nonatomic, readonly, assign) UIViewController* slidingController;
 
 @property (nonatomic, retain) UIView* panningView;
-@property (nonatomic, assign) id<UIGestureRecognizerDelegate> panningGestureDelegate;
+@property (nonatomic, ii_weak_property) __ii_weak id<UIGestureRecognizerDelegate> panningGestureDelegate;
 @property (nonatomic, assign, getter=isEnabled) BOOL enabled;
 @property (nonatomic, assign, getter=isElastic) BOOL elastic;
 


### PR DESCRIPTION
Added some compile time defines for supporting weak delegate pointers.

thanks to http://stackoverflow.com/questions/8584152/getting-expected-a-property-attribute-before-strong-when-compiling-an-arc-fi/8594878#8594878
