### PR TITLE
parallax "glitch" in combination with bouncing

### DIFF
--- a/ViewDeck/IIViewDeckController.m
+++ b/ViewDeck/IIViewDeckController.m
@@ -2404,6 +2404,7 @@ static NSTimeInterval durationToAnimate(CGFloat pointsToAnimate, CGFloat velocit
 - (CGRect) getLeftParallax {
     CGFloat pv = self.slidingControllerView.frame.origin.x;
     CGFloat diff = pv-(self.slidingControllerView.frame.size.width-_ledge[IIViewDeckLeftSide]);
+    if (diff > 0.0f) diff = 0.0f;
     
     return CGRectMake(diff*_parallaxAmount, self.leftController.view.frame.origin.y, self.leftController.view.frame.size.width, self.leftController.view.frame.size.height);
 }
@@ -2411,6 +2412,7 @@ static NSTimeInterval durationToAnimate(CGFloat pointsToAnimate, CGFloat velocit
 - (CGRect) getRightParallax {
     CGFloat pv = self.slidingControllerView.frame.origin.x;
     CGFloat diff = pv+(self.slidingControllerView.frame.size.width-_ledge[IIViewDeckRightSide]);
+    if (diff < 0.0f) diff = 0.0f;
     
     return CGRectMake(diff*_parallaxAmount, self.rightController.view.frame.origin.y, self.rightController.view.frame.size.width, self.rightController.view.frame.size.height);
 }


### PR DESCRIPTION
Hi there,

I have a small fix for the parallax in combination with bouncing for you. If parallax is enabled and the left/right side closes with bouncing or even when you drag the left/right side into the bouncing area, the mainView will become visible a bit and this does not look really nice. (even when the mainView's backgroundColor is set to black).

// Everything ok
![open](https://f.cloud.github.com/assets/1698387/250602/08ccf51c-8b4f-11e2-9264-d86602cb63f5.png)

// on the right side there is a white area (the mainWindow) - difficult to see on a white background … take a look at area of the status bar ;-)
![open-bounce](https://f.cloud.github.com/assets/1698387/250601/08ae01e8-8b4f-11e2-82f4-935b94153ad1.png)
