### PR TITLE
Enable ARC in CocoaPods

### DIFF
--- a/ViewDeck.podspec
+++ b/ViewDeck.podspec
@@ -22,4 +22,5 @@ Pod::Spec.new do |s|
                   :tag => '2.2.4'}
   s.source_files  = 'ViewDeck/*.{h,m}'
   s.frameworks    = 'QuartzCore'
+  s.requires_arc  = true
 end


### PR DESCRIPTION
If the option is missing XCode shows the following warning.

```
Pods/ViewDeck/ViewDeck/IIViewDeckController.m:950:39: '__bridge' casts have no effect when not using ARC
```
