### PR TITLE
Panning right distance calculation for "pointsToAnimate"

### DIFF
--- a/ViewDeck/IIViewDeckController.m
+++ b/ViewDeck/IIViewDeckController.m
@@ -2449,7 +2449,8 @@ static NSTimeInterval durationToAnimate(CGFloat pointsToAnimate, CGFloat velocit
                 // swipe to the right
                 
                 // Animation duration based on velocity
-                CGFloat pointsToAnimate = fabsf(self.leftSize - self.slidingControllerView.frame.origin.x);
+                CGFloat maxDistance = CGRectGetWidth(self.view.frame) - self.leftSize;
+                CGFloat pointsToAnimate = fabsf(maxDistance - self.slidingControllerView.frame.origin.x);
                 NSTimeInterval animationDuration = durationToAnimate(pointsToAnimate, orientationVelocity);
                 
                 if (v > 0) {


### PR DESCRIPTION
Fix distance calculation for panning animation when you are panning right. 

Previously, the code incorrectly subtracted the left ledge size from the X origin of the sliding view controller rather than using the ViewDeck's width minus the left ledge size.

This resulted in an incorrect number of "pointsToAnimate" which created a duration that was too fast and did not correspond properly to the orientation velocity.
