### PR TITLE
Allow delegate to alter panners configuration while a panner is active.

### DIFF
--- a/ViewDeck/IIViewDeckController.h
+++ b/ViewDeck/IIViewDeckController.h
@@ -127,6 +127,7 @@ extern IIViewDeckOffsetOrientation IIViewDeckOffsetOrientationFromIIViewDeckSide
     CGPoint _willAppearOffset;
     NSMutableArray* _finishTransitionBlocks;
     int _disabledUserInteractions;
+    BOOL _needsAddPannersIfAllPannersAreInactive;
 }
 
 typedef void (^IIViewDeckControllerBlock) (IIViewDeckController *controller, BOOL success);

--- a/ViewDeck/IIViewDeckController.m
+++ b/ViewDeck/IIViewDeckController.m
@@ -204,7 +204,8 @@ static NSTimeInterval durationToAnimate(CGFloat pointsToAnimate, CGFloat velocit
 
 - (void)addPanners;
 - (void)removePanners;
-
+- (void)setNeedsAddPanners;
+- (void)addPannersIfAllPannersAreInactiveAndNeeded;
 
 - (BOOL)checkCanOpenSide:(IIViewDeckSide)viewDeckSide;
 - (BOOL)checkCanCloseSide:(IIViewDeckSide)viewDeckSide;
@@ -892,7 +893,7 @@ static NSTimeInterval durationToAnimate(CGFloat pointsToAnimate, CGFloat velocit
             [self hideAppropriateSideViews];
         });
         
-        [self addPanners];
+        [self setNeedsAddPanners];
         
         if ([self isSideClosed:IIViewDeckLeftSide] && [self isSideClosed:IIViewDeckRightSide] && [self isSideClosed:IIViewDeckTopSide] && [self isSideClosed:IIViewDeckBottomSide])
             [self centerViewVisible];
@@ -2143,19 +2144,17 @@ static NSTimeInterval durationToAnimate(CGFloat pointsToAnimate, CGFloat velocit
 #pragma mark - center view hidden stuff
 
 - (void)centerViewVisible {
-    [self removePanners];
     if (self.centerTapper) {
         [self.centerTapper removeTarget:self action:@selector(centerTapped) forControlEvents:UIControlEventTouchUpInside];
         [self.centerTapper removeFromSuperview];
     }
     self.centerTapper = nil;
-    [self addPanners];
+    [self setNeedsAddPanners];
     [self applyShadowToSlidingViewAnimated:YES];
 }
 
 - (void)centerViewHidden {
     if (!IIViewDeckCenterHiddenIsInteractive(self.centerhiddenInteractivity)) {
-        [self removePanners];
         if (!self.centerTapper) {
             self.centerTapper = [UIButton buttonWithType:UIButtonTypeCustom];
             [self.centerTapper setBackgroundImage:nil forState:UIControlStateNormal];
@@ -2171,7 +2170,7 @@ static NSTimeInterval durationToAnimate(CGFloat pointsToAnimate, CGFloat velocit
         self.centerTapper.frame = [self.centerView bounds];
         [self setAccessibilityForCenterTapper]; // set accessibility label, hint, and frame
         
-        [self addPanners];
+        [self setNeedsAddPanners];
     }
     
     [self applyShadowToSlidingViewAnimated:YES];
@@ -2518,6 +2517,7 @@ static NSTimeInterval durationToAnimate(CGFloat pointsToAnimate, CGFloat velocit
     
     [self notifyDidCloseSide:closeSide animated:NO];
     [self notifyDidOpenSide:openSide animated:NO];
+    [self addPannersIfAllPannersAreInactiveAndNeeded];
 }
 
 - (void) setParallax {
@@ -2554,6 +2554,21 @@ static NSTimeInterval durationToAnimate(CGFloat pointsToAnimate, CGFloat velocit
     [self.panners addObject:panner];
 }
 
+- (void)setNeedsAddPanners {
+    if (_needsAddPannersIfAllPannersAreInactive)
+        return;
+    if ([self hasActivePanner])
+        _needsAddPannersIfAllPannersAreInactive = YES;
+    else
+        [self addPanners];
+}
+
+- (void)addPannersIfAllPannersAreInactiveAndNeeded {
+    if (!_needsAddPannersIfAllPannersAreInactive || [self hasActivePanner])
+        return;
+    [self addPanners];
+    _needsAddPannersIfAllPannersAreInactive = NO;
+}
 
 - (void)addPanners {
     [self removePanners];
@@ -2607,6 +2622,16 @@ static NSTimeInterval durationToAnimate(CGFloat pointsToAnimate, CGFloat velocit
     }
     [self.panners removeAllObjects];
 }
+
+- (BOOL)hasActivePanner {
+    for (UIPanGestureRecognizer *panner in self.panners) {
+        if (panner.state == UIGestureRecognizerStateBegan || panner.state == UIGestureRecognizerStateChanged) {
+            return YES;
+        }
+    }
+    return NO;
+}
+
 
 #pragma mark - Delegate convenience methods
 
@@ -2745,9 +2770,8 @@ static NSTimeInterval durationToAnimate(CGFloat pointsToAnimate, CGFloat velocit
 
 - (void)setPanningMode:(IIViewDeckPanningMode)panningMode {
     if (_viewFirstAppeared) {
-        [self removePanners];
         _panningMode = panningMode;
-        [self addPanners];
+        [self setNeedsAddPanners];
     }
     else
         _panningMode = panningMode;
@@ -2760,7 +2784,7 @@ static NSTimeInterval durationToAnimate(CGFloat pointsToAnimate, CGFloat velocit
         II_RETAIN(_panningView);
         
         if (_viewFirstAppeared && _panningMode == IIViewDeckPanningViewPanning)
-            [self addPanners];
+            [self setNeedsAddPanners];
     }
 }
 


### PR DESCRIPTION
"high-level" internal API for panners used to be `removePanners` and `addPanners`. New method `setNeedsAddPanners` should be preferred instead.

`setNeedsAddPanners` immediately replaces panners if no panner is active, or wait for the last active panner to complete before replacing them.

The consequence is that delegate methods that are fired during a panning touch can now safely change panner-related configuration, such as panningMode.

Before, those configuration change would invalidate an active panner, and prevent IIViewDeckController to perform panner completion cleanup code.

Here is the way to trigger a bug that this pull request fixes:
1. Have panningMode change, depending on which view controller is visible:

``` objc
- (void)viewDeckController:(IIViewDeckController *)viewDeckController didOpenViewSide:(IIViewDeckSide)viewDeckSide animated:(BOOL)animated
{
    viewDeckController.panningMode = IIViewDeckFullViewPanning;
}
- (void)viewDeckController:(IIViewDeckController *)viewDeckController didShowCenterViewFromSide:(IIViewDeckSide)viewDeckSide animated:(BOOL)animated
{
    viewDeckController.panningMode = IIViewDeckNavigationBarPanning;
}
```
1. Run the app :-)
2. Open a side view controller
3. Hold and drag the navigation bar until the side is totally closed. The panner must be still active when the side gets closed.
4. Stop dragging

Result : user interaction is totally disabled :'(

Expected : user interaction is enabled :-)
