### PR TITLE
Fix static analyzer warning for dead store

### DIFF
--- a/ViewDeck/IIViewDeckController.m
+++ b/ViewDeck/IIViewDeckController.m
@@ -1419,7 +1419,7 @@ static NSTimeInterval durationToAnimate(CGFloat pointsToAnimate, CGFloat velocit
     
     if (duration == DEFAULT_DURATION) duration = [self openSlideDuration:animated];
     
-    UIViewAnimationOptions options = UIViewAnimationOptionLayoutSubviews | UIViewAnimationOptionBeginFromCurrentState;
+    __block UIViewAnimationOptions options = UIViewAnimationOptionLayoutSubviews | UIViewAnimationOptionBeginFromCurrentState;
     
     IIViewDeckControllerBlock finish = ^(IIViewDeckController *controller, BOOL success) {
         if (!success) {


### PR DESCRIPTION
In `IIViewDeckController.m`, the static analyzer is warning us about a dead store:

``` objective-c
UIViewAnimationOptions options = UIViewAnimationOptionLayoutSubviews | UIViewAnimationOptionBeginFromCurrentState;

IIViewDeckControllerBlock finish = ^(IIViewDeckController *controller, BOOL success) {
    if (!success) {
        if (completed) completed(self, NO);
        return;
    }

    [self notifyWillOpenSide:side animated:animated];
    [self disableUserInteraction];
    [UIView animateWithDuration:duration delay:0 options:options animations:^{
        [self controllerForSide:side].view.hidden = NO;
        [self setSlidingFrameForOffset:[self ledgeOffsetForSide:side] forOrientation:IIViewDeckOffsetOrientationFromIIViewDeckSide(side)];
        [self centerViewHidden];
    } completion:^(BOOL finished) {
        [self enableUserInteraction];
        [self setAccessibilityForCenterTapper]; // update since the frame and the frame's intersection with the window will have changed
        if (completed) completed(self, YES);
        [self notifyDidOpenSide:side animated:animated];
        UIAccessibilityPostNotification(UIAccessibilityScreenChangedNotification, nil);
    }];
};

if ([self isSideClosed:side]) {
    // try to close any open view first
    return [self closeOpenViewAnimated:animated completion:finish];
}
else {
    options |= UIViewAnimationOptionCurveEaseOut;

    finish(self, YES);
    return YES;
}
```

Why is it warning us? We create the `options` variable, of type `UIViewAnimationOptions`, then make a block called `finish` that uses the value. The final `else` clause modifies `options`, then starts `finish`, so why is the analyzer saying that the value stored to `options` is never read?

The answer is that when `finish` is created, the value of `options` is copied into the block. Subsequent modifications to `options` don’t change its value inside the block, since the version inside the block is the copy, not the original.

This pull request adds the `__block` modifier to `options`, preventing the `finish` block from using a copy; instead, `options` always refers to the same variable and the change we make to it in the final `else` clause will take effect.
