### PR TITLE
Fix for #369, #370, #371 and #372

### DIFF
--- a/TransparencyExample/TransparencyExample.xcodeproj/xcshareddata/xcschemes/TransparencyExample.xcscheme
+++ b/TransparencyExample/TransparencyExample.xcodeproj/xcshareddata/xcschemes/TransparencyExample.xcscheme
@@ -1,0 +1,86 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "0500"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "E2B26DD91729BC3A002E650F"
+               BuildableName = "TransparencyExample.app"
+               BlueprintName = "TransparencyExample"
+               ReferencedContainer = "container:TransparencyExample.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      buildConfiguration = "Debug">
+      <Testables>
+      </Testables>
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "E2B26DD91729BC3A002E650F"
+            BuildableName = "TransparencyExample.app"
+            BlueprintName = "TransparencyExample"
+            ReferencedContainer = "container:TransparencyExample.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+   </TestAction>
+   <LaunchAction
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      buildConfiguration = "Debug"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "E2B26DD91729BC3A002E650F"
+            BuildableName = "TransparencyExample.app"
+            BlueprintName = "TransparencyExample"
+            ReferencedContainer = "container:TransparencyExample.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </LaunchAction>
+   <ProfileAction
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      buildConfiguration = "Release"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "E2B26DD91729BC3A002E650F"
+            BuildableName = "TransparencyExample.app"
+            BlueprintName = "TransparencyExample"
+            ReferencedContainer = "container:TransparencyExample.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/ViewDeck/IIViewDeckController.m
+++ b/ViewDeck/IIViewDeckController.m
@@ -1281,14 +1281,14 @@ static NSTimeInterval durationToAnimate(CGFloat pointsToAnimate, CGFloat velocit
     if (viewDeckSide == IIViewDeckNoSide)
         return;
     
-    if (_viewAppeared < to) {
+    if ((int)_viewAppeared < to) {
         _sideAppeared[viewDeckSide] = to;
         return;
     }
 
     SEL selector = nil;
     if (from < to) {
-        if (_sideAppeared[viewDeckSide] > from)
+        if ((int)_sideAppeared[viewDeckSide] > from)
             return;
         
         if (to == 1)
@@ -1297,7 +1297,7 @@ static NSTimeInterval durationToAnimate(CGFloat pointsToAnimate, CGFloat velocit
             selector = @selector(viewDidAppear:);
     }
     else {
-        if (_sideAppeared[viewDeckSide] < from)
+        if ((int)_sideAppeared[viewDeckSide] < from)
             return;
 
         if (to == 1)
@@ -1332,9 +1332,9 @@ static NSTimeInterval durationToAnimate(CGFloat pointsToAnimate, CGFloat velocit
     }
     
     [self doForControllers:^(UIViewController *controller, IIViewDeckSide side) {
-        if (from < to && _sideAppeared[side] <= from)
+        if (from < to && (int)_sideAppeared[side] <= from)
             return;
-        else if (from > to && _sideAppeared[side] >= from)
+        else if (from > to && (int)_sideAppeared[side] >= from)
             return;
         
         if ([self safe_shouldManageAppearanceMethods] && selector && controller) {
@@ -2052,7 +2052,7 @@ static NSTimeInterval durationToAnimate(CGFloat pointsToAnimate, CGFloat velocit
     }
     
     // Calculate steps
-    for (int t = 0; t < steps; t++) {
+    for (NSUInteger t = 0; t < steps; t++) {
         time = (t / (float)steps) * duration;
         offset = abs(expf(-zeta * wn * time) * ((Vo / wd) * sin(wd * time)));
         offset = direction * [self limitOffset:offset forOrientation:IIViewDeckOffsetOrientationFromIIViewDeckSide(viewDeckSide)] + position;

--- a/ViewDeck/IIViewDeckController.m
+++ b/ViewDeck/IIViewDeckController.m
@@ -447,6 +447,9 @@ static NSTimeInterval durationToAnimate(CGFloat pointsToAnimate, CGFloat velocit
 
 - (void)dealloc {
     [self cleanup];
+	
+	[self removeObserver:self forKeyPath:@"parentViewController" context:nil];
+	[self removeObserver:self forKeyPath:@"presentingViewController" context:nil];
     
     self.centerController.viewDeckController = nil;
     self.centerController = nil;

--- a/ViewDeck/IIViewDeckController.m
+++ b/ViewDeck/IIViewDeckController.m
@@ -39,10 +39,12 @@
 #define II_RETAIN(xx)  ((void)(0))
 #define II_RELEASE(xx)  ((void)(0))
 #define II_AUTORELEASE(xx)  (xx)
+#define IIBRIDGE		__bridge
 #else
 #define II_RETAIN(xx)           [xx retain]
 #define II_RELEASE(xx)          [xx release]
 #define II_AUTORELEASE(xx)      [xx autorelease]
+#define IIBRIDGE				
 #endif
 
 #define II_FLOAT_EQUAL(x, y) (((x) - (y)) == 0.0f)
@@ -3382,7 +3384,7 @@ static NSTimeInterval durationToAnimate(CGFloat pointsToAnimate, CGFloat velocit
                 if (![_shadowLayer animationForKey:@"animateShadowPath"]) {
                     anim = [CABasicAnimation animationWithKeyPath:@"shadowPath"];
                     anim.fromValue = (id)_shadowLayer.shadowPath;
-                    anim.toValue = (__bridge id)newPath;
+                    anim.toValue = (IIBRIDGE id)newPath;
                     anim.duration = duration;
                     anim.timingFunction = timingFunction;
                     anim.fillMode = kCAFillModeForwards;


### PR DESCRIPTION
#369: Deallocing IIViewDeckController causes KVO observers to not be removed
#370: Multiple warnings with -Wsign-compare
#371: Multiple warnings with -Wshadow
#372: '__bridge' casts have no effect when not using ARC