### PR TITLE
Fixed that parentViewController is not set on child controllers

### DIFF
--- a/ViewDeck/IIViewDeckController.m
+++ b/ViewDeck/IIViewDeckController.m
@@ -3201,7 +3201,6 @@ static NSTimeInterval durationToAnimate(CGFloat pointsToAnimate, CGFloat velocit
 }
 
 - (void)finishTransitionBlocks {
-    if (![self parentViewController] && ![self presentingViewController]) return;
     if (!self.referenceView) return;
     
     if (_finishTransitionBlocks) {


### PR DESCRIPTION
If IIViewDeckController is the window's rootViewController then parentViewController is nil and the _finishTransitionBlocks are never called.
This causes the IIViewDeckController's child controllers to have no parentViewController which breaks a lot of stuff like modal screens and unwind segues.

The way parent controllers are connected in ViewDeck is wrong anyway but I didn't fix that. The left, top, right and bottom controllers should always have the IIViewDeckController as parentViewController.