### PR TITLE
Removed swizzling of UIViewController's present(Modal)ViewController

### DIFF
--- a/ViewDeck/IIViewDeckController.m
+++ b/ViewDeck/IIViewDeckController.m
@@ -3517,21 +3517,6 @@ static const char* viewDeckControllerKey = "ViewDeckController";
     objc_setAssociatedObject(self, viewDeckControllerKey, viewDeckController, OBJC_ASSOCIATION_ASSIGN);
 }
 
-- (void)vdc_presentModalViewController:(UIViewController *)modalViewController animated:(BOOL)animated {
-    UIViewController* controller = self.viewDeckController ?: self;
-    [controller vdc_presentModalViewController:modalViewController animated:animated]; // when we get here, the vdc_ method is actually the old, real method
-}
-
-
-#ifdef __IPHONE_5_0
-
-- (void)vdc_presentViewController:(UIViewController *)viewControllerToPresent animated:(BOOL)animated completion:(void (^)(void))completion {
-    UIViewController* controller = self.viewDeckController ?: self;
-    [controller vdc_presentViewController:viewControllerToPresent animated:animated completion:completion]; // when we get here, the vdc_ method is actually the old, real method
-}
-
-#endif
-
 - (UINavigationController*)vdc_navigationController {
     UIViewController* controller = self.viewDeckController_core ? self.viewDeckController_core : self;
     return [controller vdc_navigationController]; // when we get here, the vdc_ method is actually the old, real method
@@ -3543,16 +3528,6 @@ static const char* viewDeckControllerKey = "ViewDeckController";
 }
 
 + (void)vdc_swizzle {
-    if (![self instancesRespondToSelector:@selector(presentViewController:animated:completion:)]) {
-        SEL presentModal = @selector(presentModalViewController:animated:);
-        SEL vdcPresentModal = @selector(vdc_presentModalViewController:animated:);
-        method_exchangeImplementations(class_getInstanceMethod(self, presentModal), class_getInstanceMethod(self, vdcPresentModal));
-    }
-    
-    SEL presentVC = @selector(presentViewController:animated:completion:);
-    SEL vdcPresentVC = @selector(vdc_presentViewController:animated:completion:);
-    method_exchangeImplementations(class_getInstanceMethod(self, presentVC), class_getInstanceMethod(self, vdcPresentVC));
-    
     SEL nc = @selector(navigationController);
     SEL vdcnc = @selector(vdc_navigationController);
     method_exchangeImplementations(class_getInstanceMethod(self, nc), class_getInstanceMethod(self, vdcnc));


### PR DESCRIPTION
… because it breaks UIViewController's presentingViewController property and thereby modal unwind segues.

iOS 5+ uses UIViewController's definesPresentationContext property to determine which controller is parent for a modal view controller. That system should handle presentation just fine even without swizzling. But this also requires that all parentViewControllers are set correctly in the way stated by Apple's documentation (see pull request #443).