### PR TITLE
Significantly improved panning performance

### DIFF
--- a/ViewDeck/IIViewDeckController.m
+++ b/ViewDeck/IIViewDeckController.m
@@ -3249,6 +3249,10 @@ static NSTimeInterval durationToAnimate(CGFloat pointsToAnimate, CGFloat velocit
 #pragma mark - Center corner radius
 
 - (void)setCenterViewCornerRadius:(CGFloat)centerViewCornerRadius {
+    if (centerViewCornerRadius == _centerViewCornerRadius) {
+        return;
+     }
+    
     _centerViewCornerRadius = centerViewCornerRadius;
     [self applyCenterViewCornerRadiusAnimated:NO];
 }
@@ -3278,6 +3282,10 @@ static NSTimeInterval durationToAnimate(CGFloat pointsToAnimate, CGFloat velocit
     UIBezierPath* path = [self generateCenterViewCornerRadiusPath];
 
     if (!self.slidingControllerView.layer.mask) {
+        if (_centerViewCornerRadius == 0) {
+            return;
+        }
+        
         self.slidingControllerView.layer.mask = [CAShapeLayer layer];
         ((CAShapeLayer*)self.slidingControllerView.layer.mask).path = [path CGPath];
     }


### PR DESCRIPTION
… when not using centerViewCornerRadius at all by not applying a mask to the IIViewDeckView.

Applying a mask to IIViewDeckView is a really bad idea in any case because it significantly hurts drawing performance! For now I just fixed it for the case where no corner radius was set at all.