### PR TITLE
Add option for Mailbox-style status bar "stick" to centre controller for iOS7

### DIFF
--- a/ViewDeck/IIViewDeckController.h
+++ b/ViewDeck/IIViewDeckController.h
@@ -169,6 +169,10 @@ typedef void (^IIViewDeckControllerBounceBlock) (IIViewDeckController *controlle
 @property (nonatomic, assign, getter=isEnabled) BOOL enabled;
 @property (nonatomic, assign, getter=isElastic) BOOL elastic;
 
+#ifdef __IPHONE_7_0
+@property (nonatomic, assign) BOOL fixStatusBarToCentreController;
+#endif
+
 @property (nonatomic, assign) CGFloat leftSize;
 @property (nonatomic, assign, readonly) CGFloat leftViewSize;
 @property (nonatomic, assign, readonly) CGFloat leftLedgeSize;

--- a/ViewDeck/IIViewDeckController.m
+++ b/ViewDeck/IIViewDeckController.m
@@ -3490,28 +3490,30 @@ static NSTimeInterval durationToAnimate(CGFloat pointsToAnimate, CGFloat velocit
         self.fixStatusBarSnapShotView.opaque = YES;
         self.fixStatusBarSnapShotView.userInteractionEnabled = NO;
         [self.centerController.view addSubview:self.fixStatusBarSnapShotView];
-
-        if (self.fixStatusBarToCentreController &&
-            [self respondsToSelector:@selector(setNeedsStatusBarAppearanceUpdate)])
-        {
-            [self setNeedsStatusBarAppearanceUpdate];
-        }
+        [self setNeedsStatusBarAppearanceUpdate];
     }
 }
 
 - (void)completionForSnapShotCenterView {
     if (self.fixStatusBarToCentreController) {
-        [self.fixStatusBarSnapShotView removeFromSuperview];
+        UIView *snapshot = self.fixStatusBarSnapShotView;
         self.fixStatusBarSnapShotView = nil;
-        if ([self respondsToSelector:@selector(setNeedsStatusBarAppearanceUpdate)]) {
-            [self setNeedsStatusBarAppearanceUpdate];
-        }
+        [self setNeedsStatusBarAppearanceUpdate];
+        dispatch_async(dispatch_get_main_queue(), ^{
+            [snapshot removeFromSuperview];
+        });
     }
 }
 
 - (BOOL)prefersStatusBarHidden {
     return !!self.fixStatusBarSnapShotView;
 }
+
+- (BOOL)fixStatusBarToCentreController {
+    return _fixStatusBarToCentreController &&
+    [self respondsToSelector:@selector(setNeedsStatusBarAppearanceUpdate)];
+}
+
 #endif
 
 @end

--- a/ViewDeck/IIViewDeckController.m
+++ b/ViewDeck/IIViewDeckController.m
@@ -1542,20 +1542,6 @@ static NSTimeInterval durationToAnimate(CGFloat pointsToAnimate, CGFloat velocit
             if (bounced) bounced(self);
             [self performDelegate:@selector(viewDeckController:didBounceViewSide:openingController:) side:side controller:_controllers[side]];
 
-            if (self.fixStatusBarToCentreController) {
-                // snapshot the new centre view controller and place it on top to hide the jump
-                UIView *view = self.centerController.view;
-                UIGraphicsBeginImageContextWithOptions(view.bounds.size, view.opaque, 0.0);
-                [view.layer renderInContext:UIGraphicsGetCurrentContext()];
-                UIImage *img = UIGraphicsGetImageFromCurrentImageContext();
-                UIGraphicsEndImageContext();
-                UIImageView *imageView = [[UIImageView alloc] initWithImage:img];
-                static const CGFloat kStandardStatusBarHeight = 20;
-                imageView.frame = CGRectOffset(imageView.frame, 0, kStandardStatusBarHeight);
-                imageView.userInteractionEnabled = NO;
-                [self.fixStatusBarSnapShotView addSubview:imageView];
-            }
-
             // now slide the view back to the ledge position
             [UIView animateWithDuration:[self openSlideDuration:YES]*shortFactor delay:0 options:UIViewAnimationOptionCurveEaseInOut | UIViewAnimationOptionLayoutSubviews | UIViewAnimationOptionBeginFromCurrentState animations:^{
                 [self setSlidingFrameForOffset:targetOffset forOrientation:IIViewDeckOffsetOrientationFromIIViewDeckSide(side) animated:YES];
@@ -1654,11 +1640,12 @@ static NSTimeInterval durationToAnimate(CGFloat pointsToAnimate, CGFloat velocit
         // run block if it's defined
         if (bounced) bounced(self);
         [self performDelegate:@selector(viewDeckController:didBounceViewSide:closingController:) side:side controller:_controllers[side]];
-        
+
         [UIView animateWithDuration:[self closeSlideDuration:YES]*longFactor delay:0 options:UIViewAnimationOptionCurveEaseOut | UIViewAnimationOptionLayoutSubviews animations:^{
             [self setSlidingFrameForOffset:0 forOrientation:IIViewDeckOffsetOrientationFromIIViewDeckSide(side) animated:YES];
             [self centerViewVisible];
         } completion:^(BOOL finished2) {
+            [self completionForSnapShotCenterView];
             [self hideAppropriateSideViews];
             [self enableUserInteraction];
             if (completed) completed(self, YES);

--- a/ViewDeck/IIViewDeckController.m
+++ b/ViewDeck/IIViewDeckController.m
@@ -3484,8 +3484,7 @@ static NSTimeInterval durationToAnimate(CGFloat pointsToAnimate, CGFloat velocit
 
 #ifdef __IPHONE_7_0
 - (void)prepareForSnapShotCenterView {
-    if ([self fixStatusBarToCentreController]) {
-        NSParameterAssert(self.fixStatusBarToCentreController);
+    if ([self fixStatusBarToCentreController] && !self.fixStatusBarSnapShotView.superview) {
         self.fixStatusBarSnapShotView = [[UIScreen mainScreen] snapshotViewAfterScreenUpdates:NO];
         self.fixStatusBarSnapShotView.opaque = YES;
         self.fixStatusBarSnapShotView.userInteractionEnabled = NO;
@@ -3495,7 +3494,7 @@ static NSTimeInterval durationToAnimate(CGFloat pointsToAnimate, CGFloat velocit
 }
 
 - (void)completionForSnapShotCenterView {
-    if (self.fixStatusBarToCentreController) {
+    if (self.fixStatusBarToCentreController && self.fixStatusBarSnapShotView.superview) {
         UIView *snapshot = self.fixStatusBarSnapShotView;
         self.fixStatusBarSnapShotView = nil;
         [self setNeedsStatusBarAppearanceUpdate];

--- a/ViewDeck/IIViewDeckController.m
+++ b/ViewDeck/IIViewDeckController.m
@@ -185,7 +185,6 @@ static NSTimeInterval durationToAnimate(CGFloat pointsToAnimate, CGFloat velocit
 
 #ifdef __IPHONE_7_0
 @property (nonatomic, ii_weak_property) __ii_weak UIView *fixStatusBarSnapShotView;
-@property (nonatomic, assign) BOOL sideMenuOpen;
 #endif
 
 - (void)cleanup;
@@ -3495,7 +3494,6 @@ static NSTimeInterval durationToAnimate(CGFloat pointsToAnimate, CGFloat velocit
         if (self.fixStatusBarToCentreController &&
             [self respondsToSelector:@selector(setNeedsStatusBarAppearanceUpdate)])
         {
-            self.sideMenuOpen = YES;
             [self setNeedsStatusBarAppearanceUpdate];
         }
     }
@@ -3503,7 +3501,6 @@ static NSTimeInterval durationToAnimate(CGFloat pointsToAnimate, CGFloat velocit
 
 - (void)completionForSnapShotCenterView {
     if (self.fixStatusBarToCentreController) {
-        self.sideMenuOpen = NO;
         [self.fixStatusBarSnapShotView removeFromSuperview];
         self.fixStatusBarSnapShotView = nil;
         if ([self respondsToSelector:@selector(setNeedsStatusBarAppearanceUpdate)]) {
@@ -3512,7 +3509,9 @@ static NSTimeInterval durationToAnimate(CGFloat pointsToAnimate, CGFloat velocit
     }
 }
 
-- (BOOL)prefersStatusBarHidden { return self.sideMenuOpen; }
+- (BOOL)prefersStatusBarHidden {
+    return !!self.fixStatusBarSnapShotView;
+}
 #endif
 
 @end

--- a/ViewDeckExample/AppDelegate.m
+++ b/ViewDeckExample/AppDelegate.m
@@ -44,7 +44,10 @@
                                                                                     leftViewController:leftController
                                                                                    rightViewController:rightController];
     deckController.rightSize = 100;
-    
+    if ([[[UIDevice currentDevice] systemVersion] floatValue] >= 7.0) {
+      deckController.fixStatusBarToCentreController = YES;
+    }
+
     [deckController disablePanOverViewsOfClass:NSClassFromString(@"_UITableViewHeaderFooterContentView")];
     return deckController;
 }


### PR DESCRIPTION
Hi,

See `fixStatusBarToCentreController` flag. Defaults to `NO`. Uses the snapshot technique to create the illusion that the status bar has stuck to the centre controller when any of the menus is open/panning. Tested with left/right/top/bottom menus, button open, pan open and bouncing. Seems to be nice and complete. Also added this to the demo app when running on 7.0+