### PR TITLE
Double check removal of KVO upon dealloc of ViewDeckController.

### DIFF
--- a/ViewDeck/IIViewDeckController.m
+++ b/ViewDeck/IIViewDeckController.m
@@ -450,15 +450,6 @@ static NSTimeInterval durationToAnimate(CGFloat pointsToAnimate, CGFloat velocit
 - (void)dealloc {
     [self cleanup];
     
-    // double check we've removed observation before nilling out the centerController
-    @try {
-        [self.centerController removeObserver:self forKeyPath:@"title"];
-        [self.centerController removeObserver:self forKeyPath:@"tabBarItem.title"];
-        [self.centerController removeObserver:self forKeyPath:@"tabBarItem.image"];
-        [self.centerController removeObserver:self forKeyPath:@"hidesBottomBarWhenPushed"];
-    } @catch(id anException) {
-        
-    }
     self.centerController.viewDeckController = nil;
     self.centerController = nil;
     self.leftController.viewDeckController = nil;

--- a/ViewDeck/IIViewDeckController.m
+++ b/ViewDeck/IIViewDeckController.m
@@ -440,20 +440,6 @@ static NSTimeInterval durationToAnimate(CGFloat pointsToAnimate, CGFloat velocit
     self.originalShadowColor = nil;
     self.originalShadowOffset = CGSizeZero;
     self.originalShadowPath = nil;
-    
-    @try {
-        [self.centerController removeObserver:self forKeyPath:@"title"];
-        [self.centerController removeObserver:self forKeyPath:@"tabBarItem.title"];
-        [self.centerController removeObserver:self forKeyPath:@"tabBarItem.iamge"];
-        [self.centerController removeObserver:self forKeyPath:@"hidesBottomBarWhenPushed"];
-    } @catch(id anException) {}
-    @try {
-        [self removeObserver:self forKeyPath:@"parentViewController"];
-        [self removeObserver:self forKeyPath:@"presentingViewController"];
-    } @catch(id anException) {}
-    @try {
-        [self.view removeObserver:self forKeyPath:@"bounds"];
-    } @catch(id anException) {}
 
     _slidingController = nil;
     self.referenceView = nil;
@@ -464,6 +450,15 @@ static NSTimeInterval durationToAnimate(CGFloat pointsToAnimate, CGFloat velocit
 - (void)dealloc {
     [self cleanup];
     
+    // double check we've removed observation before nilling out the centerController
+    @try {
+        [self.centerController removeObserver:self forKeyPath:@"title"];
+        [self.centerController removeObserver:self forKeyPath:@"tabBarItem.title"];
+        [self.centerController removeObserver:self forKeyPath:@"tabBarItem.image"];
+        [self.centerController removeObserver:self forKeyPath:@"hidesBottomBarWhenPushed"];
+    } @catch(id anException) {
+        
+    }
     self.centerController.viewDeckController = nil;
     self.centerController = nil;
     self.leftController.viewDeckController = nil;
@@ -472,6 +467,18 @@ static NSTimeInterval durationToAnimate(CGFloat pointsToAnimate, CGFloat velocit
     self.rightController = nil;
     self.panners = nil;
     
+    // observations related to UIViewController properties
+    @try {
+        [self removeObserver:self forKeyPath:@"parentViewController"];
+        [self removeObserver:self forKeyPath:@"presentingViewController"];
+    } @catch(id anException) {
+        
+    }
+    @try {
+        [self.view removeObserver:self forKeyPath:@"bounds"];
+    } @catch(id anException) {
+    
+    }
 #if !II_ARC_ENABLED
     [super dealloc];
 #endif

--- a/ViewDeck/IIViewDeckController.m
+++ b/ViewDeck/IIViewDeckController.m
@@ -183,6 +183,8 @@ static NSTimeInterval durationToAnimate(CGFloat pointsToAnimate, CGFloat velocit
 @property (nonatomic, retain) UIButton* centerTapper;
 @property (nonatomic, retain) UIView* centerView;
 @property (nonatomic, readonly) UIView* slidingControllerView;
+@property (nonatomic, assign) BOOL isObservingView;
+@property (nonatomic, assign) BOOL isObservingSelf;
 
 - (void)cleanup;
 - (uint)sideControllerCount;
@@ -459,16 +461,22 @@ static NSTimeInterval durationToAnimate(CGFloat pointsToAnimate, CGFloat velocit
     self.panners = nil;
     
     // observations related to UIViewController properties
-    @try {
-        [self removeObserver:self forKeyPath:@"parentViewController"];
-        [self removeObserver:self forKeyPath:@"presentingViewController"];
-    } @catch(id anException) {
-        
+    if (self.isObservingSelf) {
+        @try {
+            [self removeObserver:self forKeyPath:@"parentViewController"];
+            [self removeObserver:self forKeyPath:@"presentingViewController"];
+            self.isObservingSelf = NO;
+        } @catch(id anException) {
+            
+        }
     }
-    @try {
-        [self.view removeObserver:self forKeyPath:@"bounds"];
-    } @catch(id anException) {
-    
+    if (self.isObservingView) {
+        @try {
+            [self.view removeObserver:self forKeyPath:@"bounds"];
+            self.isObservingView = NO;
+        } @catch(id anException) {
+            
+        }
     }
 #if !II_ARC_ENABLED
     [super dealloc];
@@ -957,6 +965,7 @@ static NSTimeInterval durationToAnimate(CGFloat pointsToAnimate, CGFloat velocit
     [super viewWillAppear:animated];
     
     [self.view addObserver:self forKeyPath:@"bounds" options:NSKeyValueObservingOptionNew context:nil];
+    self.isObservingView = YES;
 
     if (!_viewFirstAppeared) {
         _viewFirstAppeared = YES;
@@ -1052,10 +1061,13 @@ static NSTimeInterval durationToAnimate(CGFloat pointsToAnimate, CGFloat velocit
     if (self.navigationControllerBehavior == IIViewDeckNavigationControllerIntegrated)
         _willAppearOffset = self.slidingControllerView.frame.origin;
 
-    @try {
-        [self.view removeObserver:self forKeyPath:@"bounds"];
-    } @catch(id anException){
-        //do nothing, obviously it wasn't attached because an exception was thrown
+    if (self.isObservingView) {
+        @try {
+            [self.view removeObserver:self forKeyPath:@"bounds"];
+            self.isObservingView = NO;
+        } @catch(id anException){
+            //do nothing, obviously it wasn't attached because an exception was thrown
+        }
     }
     
     if ([self safe_shouldManageAppearanceMethods]) {
@@ -3282,6 +3294,7 @@ static NSTimeInterval durationToAnimate(CGFloat pointsToAnimate, CGFloat velocit
             II_RETAIN(_finishTransitionBlocks);
             [self addObserver:self forKeyPath:@"parentViewController" options:0 context:nil];
             [self addObserver:self forKeyPath:@"presentingViewController" options:0 context:nil];
+            self.isObservingSelf = YES;
         }
         [_finishTransitionBlocks addObject:finishTransition];
     }
@@ -3291,8 +3304,15 @@ static NSTimeInterval durationToAnimate(CGFloat pointsToAnimate, CGFloat velocit
     if (!self.referenceView) return;
     
     if (_finishTransitionBlocks) {
-        [self removeObserver:self forKeyPath:@"parentViewController" context:nil];
-        [self removeObserver:self forKeyPath:@"presentingViewController" context:nil];
+        if (self.isObservingSelf) {
+            @try {
+                [self removeObserver:self forKeyPath:@"parentViewController" context:nil];
+                [self removeObserver:self forKeyPath:@"presentingViewController" context:nil];
+                self.isObservingSelf = NO;
+            } @catch (id anException) {
+                
+            }
+        }
         
         for (void(^finishTransition)(void) in _finishTransitionBlocks) {
             finishTransition();

--- a/ViewDeck/IIViewDeckController.m
+++ b/ViewDeck/IIViewDeckController.m
@@ -441,6 +441,20 @@ static NSTimeInterval durationToAnimate(CGFloat pointsToAnimate, CGFloat velocit
     self.originalShadowOffset = CGSizeZero;
     self.originalShadowPath = nil;
     
+    @try {
+        [self.centerController removeObserver:self forKeyPath:@"title"];
+        [self.centerController removeObserver:self forKeyPath:@"tabBarItem.title"];
+        [self.centerController removeObserver:self forKeyPath:@"tabBarItem.iamge"];
+        [self.centerController removeObserver:self forKeyPath:@"hidesBottomBarWhenPushed"];
+    } @catch(id anException) {}
+    @try {
+        [self removeObserver:self forKeyPath:@"parentViewController"];
+        [self removeObserver:self forKeyPath:@"presentingViewController"];
+    } @catch(id anException) {}
+    @try {
+        [self.view removeObserver:self forKeyPath:@"bounds"];
+    } @catch(id anException) {}
+
     _slidingController = nil;
     self.referenceView = nil;
     self.centerView = nil;


### PR DESCRIPTION
There are situations where the viewDeckController may be deallocated without the normal view lifecycle delegate methods being called. This results in the "bounds" keyPath on the `self.view` observation remaining in place when the view is deallocated in the call to `[super dealloc]`.

This change generalizes the issue to any observation which may have, for whatever reason, survived to dealloc. I grouped the removal attempts into separate @try blocks based on the grouping they have when created, and placed each block near to where the related field would be cleared.

Note: there are other KVO improvements we could make here, and I am willing to contribute further PRs in this area if the maintainers are interested.