### PR TITLE
Remove annotation available only from Xcode 7

### DIFF
--- a/ViewDeck/IIViewDeckController.m
+++ b/ViewDeck/IIViewDeckController.m
@@ -1245,7 +1245,7 @@ static NSTimeInterval durationToAnimate(CGFloat pointsToAnimate, CGFloat velocit
     _preRotationCenterSize = self.centerView.bounds.size;
     _preRotationIsLandscape = UIInterfaceOrientationIsLandscape(self.interfaceOrientation);
     
-    [coordinator animateAlongsideTransition:NULL completion:^(id<UIViewControllerTransitionCoordinatorContext>  _Nonnull context) {
+    [coordinator animateAlongsideTransition:NULL completion:^(id<UIViewControllerTransitionCoordinatorContext> context) {
         [self arrangeViewsAfterRotation];
         
         [self applyCenterViewCornerRadiusAnimated:NO];


### PR DESCRIPTION
Currently using `ViewDeck` with Xcode 6, compilation fails. This happens because of usage of `_Nonnull` annotation which is available only from Xcode 7. 

![screenshot 2015-12-03 18 53 41](https://cloud.githubusercontent.com/assets/1570541/11561770/8c36aacc-99ef-11e5-8b37-4e2708ea2943.png)

This error makes project not even compilable.