### PR TITLE
Add condition for KVO "bounds"

### DIFF
--- a/ViewDeck/IIViewDeckController.m
+++ b/ViewDeck/IIViewDeckController.m
@@ -961,8 +961,10 @@ static NSTimeInterval durationToAnimate(CGFloat pointsToAnimate, CGFloat velocit
 - (void)viewWillAppear:(BOOL)animated {
     [super viewWillAppear:animated];
     
-    [self.view addObserver:self forKeyPath:@"bounds" options:NSKeyValueObservingOptionNew context:nil];
-    self.isObservingView = YES;
+    if (!self.isObservingView) {
+        [self.view addObserver:self forKeyPath:@"bounds" options:NSKeyValueObservingOptionNew context:nil];
+        self.isObservingView = YES;
+    }
 
     if (!_viewFirstAppeared) {
         _viewFirstAppeared = YES;


### PR DESCRIPTION
Hi, I found a situation that KVO could cause the application to crash. First I pushed a IIViewDeckController with center and left view from a navigationController, then i used pan gesture to pop this controller and canceled it before the controller was really disappeared, when i popped this controller again, the application crashed. For more specific, please see this gif [http://blog.quweimian.com/wp-content/uploads/2016/02/viewdeck_sample.gif](url)
I think it is because that when i using pan gesture, the method ViewWillAppear execute again, the KVO for “bounds” add again. So i added this condition, the problem solved ^_^