### PR TITLE
fix: IBDesignablesAgent crash on rendering IB_DESIGNABLE views

### DIFF
--- a/ViewDeck/IIViewDeckController.m
+++ b/ViewDeck/IIViewDeckController.m
@@ -3537,6 +3537,8 @@ static NSTimeInterval durationToAnimate(CGFloat pointsToAnimate, CGFloat velocit
 
 @end
 
+#if !TARGET_INTERFACE_BUILDER
+
 @implementation UIViewController (UIViewDeckItem)
 
 @dynamic viewDeckController;
@@ -3716,6 +3718,8 @@ static const char* viewDeckControllerKey = "ViewDeckController";
 }
 
 @end
+
+#endif
 
 
 #pragma clang diagnostic pop


### PR DESCRIPTION
Hi,
Unfortunately swizzling of UIView/UIViewController methods crashes IBDesignablesAgent when it tries to render IB_DESIGNABLE views in Interface Builder. I suggest escaping swizzling for TARGET_INTERFACE_BUILDER.
And it seems to me a better approach for swizzling was described by Peter Steingberg in the following blog post:
http://petersteinberger.com/blog/2014/a-story-about-swizzling-the-right-way-and-touch-forwarding/

Looking forward to hearing from you.